### PR TITLE
Fix entry actions hover on Firefox

### DIFF
--- a/app/styles/_entry.scss
+++ b/app/styles/_entry.scss
@@ -123,15 +123,15 @@
 .entry-actions {
   display: none;
   position: absolute;
-  left: 0;
-  top: 50%;
-  transform: translate(-100%, -50%);
+  right: 100%;
+  top: 0;
 }
 
 .entry-action {
   display: flex;
   justify-content: center;
   align-items: center;
+  padding: $sp-sm 0;
 }
 
 .entry-action-delete-img, .entry-action-cancel-img, .entry-action-restart-img {


### PR DESCRIPTION
Sometimes hovering an entry and then move the cursor to its actions make
the actions disappear, especially when the zoom level is below 90%